### PR TITLE
Object types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 /lib/
 /.crystal/
 /.shards/
-
+/.crystal-version
 
 # Libraries don't need dependency lock
 # Dependencies will be locked in application that uses them

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: kemal-session-redis
-version: 0.2.0
+version: 0.3.0
 
 dependencies:
   kemal-session:
@@ -9,13 +9,8 @@ dependencies:
     github: ysbaddaden/pool
     version: 0.2.3
   redis:
-    github: kostya/crystal-redis
-    commit: "8d7e44805c64100dbc4c6abfb4a5f33267b77908"
-  # until kostya fix for crystal 0.20.3 can be committed to main repo
-  # a new version of kemal-session-redis wont be released
-  #redis:
-    #github: stefanwille/crystal-redis
-    #version: ~> 1.6.7
+    github: stefanwille/crystal-redis
+    version: ~> 1.7.0
 
 authors:
   - Rimas Silkaitis <neovintage@gmail.com>

--- a/shard.yml
+++ b/shard.yml
@@ -9,8 +9,13 @@ dependencies:
     github: ysbaddaden/pool
     version: 0.2.3
   redis:
-    github: stefanwille/crystal-redis
-    version: ~> 1.6.7
+    github: kostya/crystal-redis
+    commit: "8d7e44805c64100dbc4c6abfb4a5f33267b77908"
+  # until kostya fix for crystal 0.20.3 can be committed to main repo
+  # a new version of kemal-session-redis wont be released
+  #redis:
+    #github: stefanwille/crystal-redis
+    #version: ~> 1.6.7
 
 authors:
   - Rimas Silkaitis <neovintage@gmail.com>

--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.2.0
 dependencies:
   kemal-session:
     github: kemalcr/kemal-session
-    version: 0.5.0
+    branch: master
   pool:
     github: ysbaddaden/pool
     version: 0.2.3

--- a/spec/kemal-session-redis_spec.cr
+++ b/spec/kemal-session-redis_spec.cr
@@ -68,6 +68,26 @@ describe "Session::RedisEngine" do
     end
   end
 
+  describe ".object" do
+    it "can be saved and retrieved" do
+      session = Session.new(create_context(SESSION_ID))
+      u = UserJsonSerializer.new(123, "charlie")
+      session.object("user", u)
+      new_u = session.object("user").as(UserJsonSerializer)
+      new_u.id.should eq(123)
+      new_u.name.should eq("charlie")
+    end
+
+    it "can handle non-json serializers" do
+      session = Session.new(create_context(SESSION_ID))
+      u = UserCommaSerializer.new(456, "lucy")
+      session.object("peanuts", u)
+      new_u = session.object("peanuts").as(UserCommaSerializer)
+      new_u.id.should eq(456)
+      new_u.name.should eq("lucy")
+    end
+  end
+
   describe ".destroy" do
     it "should remove session from redis" do
       session = Session.new(create_context(SESSION_ID))

--- a/spec/kemal-session-redis_spec.cr
+++ b/spec/kemal-session-redis_spec.cr
@@ -2,16 +2,42 @@ require "./spec_helper"
 
 describe "Session::RedisEngine" do
   describe "options" do
-    describe "url" do
-      it "raises an ArgumentError if not passed" do
-        expect_raises(ArgumentError) do
-          Session::RedisEngine.new({ :whatever => "else" })
-        end
-      end
-
-      it "can be successfully set up" do
-      end
+    it "can config a new redis with options" do
+      eng = Session::RedisEngine.new(
+              host: "localhost",
+              port: 6379
+            )
+      eng.should_not be_nil
     end
 
+    it "can pass a connection pool" do
+      pool = ConnectionPool.new(capacity: 1, timeout: 1.0) do
+        Redis.new
+      end
+      eng = Session::RedisEngine.new({ :pool => pool })
+      eng.should_not be_nil
+    end
+  end
+
+  describe ".int" do
+  end
+
+  describe ".bool" do
+  end
+
+  describe ".float" do
+  end
+
+  describe ".string" do
+    it "can save a value" do
+      session = Session.new(create_context("foo"))
+      session.string("bar", "kemal")
+    end
+
+    it "can retrieve a saved value" do
+      session = Session.new(create_context("foo"))
+      session.string("bar", "kemal")
+      session.string("bar").should eq "kemal"
+    end
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -28,3 +28,35 @@ def create_context(session_id : String)
   request = HTTP::Request.new("GET", "/", headers)
   return HTTP::Server::Context.new(request, response)
 end
+
+class UserJsonSerializer < Session::StorableObject
+  JSON.mapping({
+    id: Int32,
+    name: String
+  })
+
+  def initialize(@id : Int32, @name : String); end
+
+  def serialize
+    self.to_json
+  end
+
+  def self.unserialize(value : String)
+    UserJsonSerializer.from_json(value)
+  end
+end
+
+class UserCommaSerializer < Session::StorableObject
+  property id, name
+
+  def initialize(@id : Int32, @name : String); end
+
+  def serialize
+    return "#{@id},#{@name}"
+  end
+
+  def self.unserialize(value : String)
+    parts = value.split(",")
+    return self.new(parts[0], parts[1])
+  end
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -57,6 +57,6 @@ class UserCommaSerializer < Session::StorableObject
 
   def self.unserialize(value : String)
     parts = value.split(",")
-    return self.new(parts[0], parts[1])
+    return self.new(parts[0].to_i, parts[1])
   end
 end

--- a/src/kemal-session-redis.cr
+++ b/src/kemal-session-redis.cr
@@ -13,7 +13,7 @@ class Session
           if pull.kind == :null
             pull.read_next
           else
-            hash[key] = StorableObject.unserialize(pull)
+            hash[key] = StorableObject.unserialize(pull.read_string)
           end
         end
         hash
@@ -71,7 +71,7 @@ class Session
       define_storage({int: Int32, string: String, float: Float64, bool: Bool, object: StorableObject})
     end
 
-    @pool  : ConnectionPool(Redis)
+    @redis  : ConnectionPool(Redis)
     @cache : StorageInstance
     @cached_session_id : String
 
@@ -132,13 +132,13 @@ class Session
     end
 
     def save_cache
-      conn = @pool.checkout
+      conn = @redis.checkout
       conn.set(
         prefix_session(@cached_session_id),
         @cache.to_json,
         ex: Session.config.timeout.total_seconds.to_i
       )
-      @pool.checkin(conn)
+      @redis.checkin(conn)
     end
 
     def is_in_cache?(session_id)

--- a/src/kemal-session-redis/version.cr
+++ b/src/kemal-session-redis/version.cr
@@ -1,3 +1,3 @@
 module Kemal::Session::Redis
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
This PR includes support for kemal-session `StorableObject` type and updates the library to work with crystal 0.20.3. Unfortunately, this PR can't be merged until the main crystal-redis repo fixes the [issues](https://github.com/stefanwille/crystal-redis/pull/32) with crystal 0.20.3. Currently in the shard.yml file, I'm using a forked repo to get all of the code fixes in place. 