### PR TITLE
Ensure inline version matches shard.yml

### DIFF
--- a/src/kemal-session-redis/version.cr
+++ b/src/kemal-session-redis/version.cr
@@ -1,3 +1,3 @@
 module Kemal::Session::Redis
-  VERSION = "0.5.0"
+  VERSION = {{ `shards version "#{__DIR__}"`.chomp.stringify }}
 end


### PR DESCRIPTION
This change should ideally make it easier to bump versions. This way it's only needed to bump the version stated in `shard.yml` file and the inline version should match that.

Solution taken from [ameba shard](https://github.com/crystal-ameba/ameba/blob/master/src/ameba.cr#L28)